### PR TITLE
This fixes the alignment overlap issue with the main items

### DIFF
--- a/t&s landing page/contact.html
+++ b/t&s landing page/contact.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/css/style.css">
-    <link rel="stylesheet" href="/css/transitions.css">
-    <script src="/js/main.js" defer></script>
+    <link rel="stylesheet" href="./css/style.css">
+    <link rel="stylesheet" href="./css/transitions.css">
+    <script src="./js/main.js" defer></script>
     <title>Document</title>
 </head>
 <body>
-    <img src="/images/logo.PNG" class="logo">
+    <img src="./images/logo.PNG" class="logo">
     <p class="logo-text">Thés Et Saveurs</p>
     <div class="topnav-container">
-        <a href="/index.html" class="nav">Accueil</a>
-        <a href="/download.html" class="nav">Télécharger</a>
-        <a href="/contact.html" class="active-nav">Contacter</a>
+        <a href="./index.html" class="nav">Accueil</a>
+        <a href="./download.html" class="nav">Télécharger</a>
+        <a href="./contact.html" class="active-nav">Contacter</a>
     </div>
 </body>
 </html>

--- a/t&s landing page/css/style.css
+++ b/t&s landing page/css/style.css
@@ -37,49 +37,122 @@ body {
     right: 10px;
 }
 .mockup {
-    width: 200px;
+    width: 300px;
     display: block;
-    margin: auto;
-    position: relative;
-    top: 50px;
     border-radius: 40px;
+}
+
+.btn-container {
+    display: flex;
+    gap: 20px;
+    position: relative;
+    top: 100px;
+    left: 0%;
+    max-width: 420px;
+    height:35%;
+}
+conteneur-main {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+conteneur-de-droit{
+    display:block;
+    width:45%;
+}
+
+
+conteneur-de-gauche{
+    display: flex;
+    flex-direction: column;
+    width:55%;
+    margin-left: 15%;
 }
 .title {
     font-family: 'Inter', sans-serif;
     font-weight: 900;
-    font-size: 35px;
-    text-align: center;
+    text-align: left;
     position: relative;
     top: 50px;
+    font-size: 60px;
+    text-align: none;
+    left: 0%;
+    top: 100px;
+
+
+
 }
 .caption {
+    margin-top:45px;
     font-family: 'Lexend Deca', sans-serif;
     font-weight: 400;
-    font-size: 20px;
     position: relative;
     top: 30px;
-    text-align: center;
+    text-align: left;
     color: rgb(92, 91, 91);
+    font-size: 25px;
+    position: relative;
+    text-align: left;
+    left: 0%;
+    color: grey;
+
+
+
 }
 .btn-1 {
-    display: none;
+    background: #fdc733;
+    color: black;
+    border: none;
+    border-radius: 5px;
+    width: 200px;
+    height: 40px;
+    display: block;
+    font-family: 'Lexend Deca', sans-serif;
+    font-weight: 700;
+    font-size: 25px;
+    cursor: pointer;
+    transition: background .1s;
 }
 .btn-2 {
-    display: none;
+    background: #fdc733;
+    color: black;
+    border: none;
+    border-radius: 5px;
+    width: 200px;
+    height: 40px;
+    display: block;
+    font-family: 'Inter', sans-serif;
+    font-weight: 700;
+    font-size: 25px;
+    cursor: pointer;
+    transition: background .1s;
 }
-@media only screen and (min-width: 768px) {
+@media only screen and (max-width: 768px) {
     .mockup {
-        width: 300px;
+        width: 200px;
+        display: block;
+        margin: auto;
         position: relative;
-        float: right;
-        right: 5%;
-        top: 100px;
+        top: 50px;
+        border-radius: 40px;
     }
+    conteneur-main {
+
+        flex-direction: column-reverse;
+    }
+    
+    conteneur-de-gauche{
+        margin-left:15%;
+    }
+
+
+
     .title {
         font-size: 60px;
         position: relative;
         text-align: none;
-        left: 1%;
+        left: 0%;
         top: 100px;
     }
     .caption {
@@ -87,7 +160,7 @@ body {
         position: relative;
         text-align: left;
         top: 80px;
-        left: 15%;
+        left: 0%;
         color: grey;
     } 
     .btn-1 {
@@ -132,7 +205,7 @@ body {
         gap: 20px;
         position: relative;
         top: 100px;
-        left: 15%;
+        left: 0%;
         max-width: 420px;
     }
   }

--- a/t&s landing page/css/style.css
+++ b/t&s landing page/css/style.css
@@ -36,11 +36,12 @@ body {
     top: 30px;
     right: 10px;
 }
-.mockup {
-    width: 300px;
-    display: block;
-    border-radius: 40px;
-}
+    .mockup {
+        width: 300px;
+        right: 5%;
+        top: 100px;
+        border-radius:40px;
+    }
 
 .btn-container {
     display: flex;
@@ -136,33 +137,37 @@ conteneur-de-gauche{
         position: relative;
         top: 50px;
         border-radius: 40px;
+        right: 0%;
     }
     conteneur-main {
 
         flex-direction: column-reverse;
+        align-items: center;
+        justify-content: center;
     }
     
     conteneur-de-gauche{
-        margin-left:15%;
+        margin-left:0%;
     }
-
 
 
     .title {
-        font-size: 60px;
+        font-family: 'Inter', sans-serif;
+        font-weight: 900;
+        font-size: 35px;
+        text-align: center;
         position: relative;
-        text-align: none;
-        left: 0%;
-        top: 100px;
+        top: 50px;
     }
     .caption {
-        font-size: 25px;
+   
+        font-weight: 400;
+        font-size: 20px;
         position: relative;
-        text-align: left;
-        top: 80px;
-        left: 0%;
-        color: grey;
-    } 
+        top: 30px;
+        text-align: center;
+        color: rgb(92, 91, 91);
+    }
     .btn-1 {
         background: #fdc733;
         color: black;

--- a/t&s landing page/download.html
+++ b/t&s landing page/download.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/css/style.css">
-    <link rel="stylesheet" href="/css/transitions.css">
-    <script src="/js/main.js" defer></script>
+    <link rel="stylesheet" href="./css/style.css">
+    <link rel="stylesheet" href="./css/transitions.css">
+    <script src="./js/main.js" defer></script>
     <title>Document</title>
 </head>
 <body>
-    <img src="/images/logo.PNG" class="logo">
+    <img src="./images/logo.PNG" class="logo">
     <p class="logo-text">Thés Et Saveurs</p>
     <div class="topnav-container">
-        <a href="/index.html" class="nav">Accueil</a>
-        <a href="/download.html" class="active-nav">Télécharger</a>
-        <a href="/contact.html" class="nav">Contacter</a>
+        <a href="./index.html" class="nav">Accueil</a>
+        <a href="./download.html" class="active-nav">Télécharger</a>
+        <a href="./contact.html" class="nav">Contacter</a>
     </div>
 </body>
 </html>

--- a/t&s landing page/index.html
+++ b/t&s landing page/index.html
@@ -4,26 +4,34 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/css/style.css">
-    <script src="/js/main.js" defer></script>
+    <link rel="stylesheet" href="./css/style.css">
+    <script src="./js/main.js" defer></script>
     <title>Thés Et Saveurs</title>
 </head>
 <body>
     <div class="all">
-    <img src="/images/logo.PNG" class="logo">
+    <img src="./images/logo.PNG" class="logo">
     <p class="logo-text">Thés Et Saveurs</p>
     <div class="topnav-container">
-        <a href="/index.html" class="active-nav">Accueil</a>
-        <a href="/download.html" class="nav">Télécharger</a>
-        <a href="/contact.html" class="nav">Contacter</a>
-    </div>
-    <img src="/images/mockup.png" class="mockup">
-    <h1 class="title">Thés Et Saveurs</h1>
-    <p class="caption">Bientôt disponible sur toutes <br> les plateformes !</p> 
-    <div class="btn-container">
-    <button class="btn-1">Ouvrir</button>
-    <button class="btn-2">Contacter</button>
-    </div>
+        <a href="./index.html" class="active-nav">Accueil</a>
+        <a href="./download.html" class="nav">Télécharger</a>
+        <a href="./contact.html" class="nav">Contacter</a>
+    </div>    
+    <conteneur-main>
+        <conteneur-de-gauche>
+            <h1 class="title">Thés Et Saveurs</h1>
+            <p class="caption">Bientôt disponible sur toutes <br> les plateformes !</p> 
+            <div class="btn-container">
+                <button class="btn-1">Ouvrir</button>
+                <button class="btn-2">Contacter</button>
+            </div>
+            
+        </conteneur-de-gauche>
+        <conteneur-de-droit>
+        <img src="./images/mockup.png" class="mockup">
+       </conteneur-de-droit>
+    </conteneur-main>    
+    
 </div>
 </body>
 </html>


### PR DESCRIPTION
The Issue where the main image and left items overlap on screen resize has been fixed. I moved the media queries for mobile to the bottom and changed the query from (min-width: 768px) to (max-width: 768px) in order to better organize styles.

I revised the index.html to have a main container, left items & right items and aligned them accordingly using flexbox and the aforementioned CSS media queries. Margins, padding, etc can be added or changed to revise the spacing between items like the title and caption.